### PR TITLE
change guides(color = FALSE) to guides(color = "none")

### DIFF
--- a/R/itemInfoPlot.r
+++ b/R/itemInfoPlot.r
@@ -64,6 +64,7 @@ itemInfoPlot <- function(model,
     
   if(isFALSE(legend)) {
     p <- p + guides(color = FALSE)
+    # change guides(color = "none")
   }
     
   } else {


### PR DESCRIPTION
The `<scale>` argument of `guides()` cannot be `FALSE`. Use "none" instead as of ggplot2 3.3.4. please see https://ggplot2.tidyverse.org/news/index.html