### PR TITLE
bug fixes in cases where model contains more than 9 items

### DIFF
--- a/R/itemInfoPlot.r
+++ b/R/itemInfoPlot.r
@@ -49,7 +49,9 @@ itemInfoPlot <- function(model,
   test <- as.data.frame(test, theta) %>%
     tibble::rownames_to_column("theta") %>%
     gather(key, value, -theta) %>%
-    mutate(theta = as.numeric(theta))
+    mutate(theta = as.numeric(theta),
+           key = gsub(".", " ", key, fixed = T))
+  test$key <- factor(test$key, levels = c(paste('item', 1:length(unique(test$key)))))
   
   # final plot
   if(isFALSE(facet)) {

--- a/R/itemInfoPlot.r
+++ b/R/itemInfoPlot.r
@@ -59,8 +59,13 @@ itemInfoPlot <- function(model,
            y = expression(I(theta)), 
            title = title,
            color = "Item") +
-      theme_minimal() +
+      theme_minimal() 
+
+    # in cases where there are max 9 items: use a specified color palette
+    if (length(unique(test$key)) < 10) {
+      p <- p +
       scale_color_brewer(palette = 7)
+    }
     
   if(isFALSE(legend)) {
     p <- p + guides(color = FALSE)

--- a/R/tracePlot.r
+++ b/R/tracePlot.r
@@ -57,8 +57,14 @@ tracePlot <- function(model,
       theme_minimal() +
       labs(x = expression(theta), 
            y = expression(P(theta)), 
-           title = title) +
-      scale_color_brewer(palette = 7)
+           title = title) 
+    
+    # in cases where there are max 9 items: use a specified color palette
+    if (length(unique(trace$var)) < 10) {
+      p <- p +
+        scale_color_brewer(palette = 7)
+    }
+    
     
   } else {
   
@@ -87,8 +93,13 @@ tracePlot <- function(model,
     labs(x = expression(theta), 
          y = expression(P(theta)), 
          title = title) +
-    theme_minimal() +
-    scale_color_brewer(palette = 7)
+    theme_minimal() 
+  
+  # in cases where there are max 9 items: use a specified color palette
+  if (length(unique(d$item)) < 10) {
+    p <- p +
+      scale_color_brewer(palette = 7)
+  }
   
   if(isFALSE(legend)) {
    p <- p + guides(color = "none")

--- a/R/tracePlot.r
+++ b/R/tracePlot.r
@@ -84,7 +84,7 @@ tracePlot <- function(model,
   
   item <- rep(names(trace), each = length(theta))
   d <- cbind.data.frame(theta, item, trace_df)
-  d$item <- as.factor(d$item)
+  d$item <- factor(d$item, levels = c(paste('item', 1:length(trace))))
   
   # final plot
   if(isFALSE(facet)) {


### PR DESCRIPTION
Small changes to the code to make the graphs easier to read when more than 9 items are used. The applied fix deals with "Warning: n too large, allowed maximum for palette Oranges is 9 Returning the palette you asked for with that many colors" by only defining the colour brewer palette when there are less than 10 items. By declaring the variable that contains item levels to be a factor with labels, the order in the legend is correctly preserved. 
![itemInfoPlot_after](https://github.com/masurp/ggmirt/assets/55539825/dc795ce9-e2a3-46a3-aeb8-c4acf17bcce8)
![itemInfoPlot_before](https://github.com/masurp/ggmirt/assets/55539825/0dcd7873-3be7-4ae6-8f70-fcdbdbcff661)
![traceplot_after](https://github.com/masurp/ggmirt/assets/55539825/edcb1899-e547-4fb6-a332-c9fed63c73ab)
![tracePlot_before](https://github.com/masurp/ggmirt/assets/55539825/61c14601-b2be-4ce5-8ba9-32c1404f8b81)
